### PR TITLE
Removed tokens from initial auth response

### DIFF
--- a/src/spotify-playlist.coffee
+++ b/src/spotify-playlist.coffee
@@ -46,9 +46,6 @@ requestInitialTokens = (res, func) ->
       robot.brain.set 'access_token', response.access_token
       robot.brain.set 'refresh_token', response.refresh_token
       robot.brain.set 'expires', (new Date().getTime() + (response.expires_in * 1000))
-      res.send body
-      res.send response.access_token
-      res.send response.refresh_token
       func(res)
 
 refreshAccessToken = (res, func) ->


### PR DESCRIPTION
I just removed them from the response. Didn't add any message here since it should just work without the user caring if the auth succeeded. If the search/add/delete commands are functional, then that's all that should matter, right? :)

Resolves: https://github.com/postlight/hubot-spotify-playlist/issues/4